### PR TITLE
LLVM 15 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: tools/setup.sh
-      - run: cargo clippy
+      - run: cargo clippy -- -D warnings
   format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,41 +5,27 @@ on:
       - main
   pull_request:
 jobs:
-  # TODO Enable this when LLVM 15 is available in Homebrew.
-  # test:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os:
-  #         - ubuntu-22.04
-  #         - macos-12
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: tools/setup.sh
-  #     - run: cargo test
-  # lint:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: tools/setup.sh
-  #     - run: cargo clippy -- -D warnings
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          # TODO Enable this when LLVM 15 is available in Homebrew.
+          # - macos-12
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: tools/setup.sh
+      - run: cargo test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: tools/setup.sh
+      - run: cargo clippy -- -D warnings
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: cargo fmt --check
-  test_llvm_15:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
-      - run: sudo apt -y install libmlir-15-dev mlir-15-tools
-      - run: PATH=/usr/lib/llvm-15/bin:$PATH cargo test
-  lint_llvm_15:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
-      - run: sudo apt -y install libmlir-15-dev mlir-15-tools
-      - run: PATH=/usr/lib/llvm-15/bin:$PATH cargo clippy -- -D warnings

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,26 +5,41 @@ on:
       - main
   pull_request:
 jobs:
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-22.04
-          - macos-12
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - run: tools/setup.sh
-      - run: cargo test
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: tools/setup.sh
-      - run: cargo clippy -- -D warnings
+  # TODO Enable this when LLVM 15 is available in Homebrew.
+  # test:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os:
+  #         - ubuntu-22.04
+  #         - macos-12
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: tools/setup.sh
+  #     - run: cargo test
+  # lint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: tools/setup.sh
+  #     - run: cargo clippy -- -D warnings
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: cargo fmt --check
+  test_llvm_15:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
+      - run: sudo apt -y install libmlir-15-dev mlir-15-tools
+      - run: PATH=/usr/lib/llvm-15/bin:$PATH cargo test
+  lint_llvm_15:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
+      - run: sudo apt -y install libmlir-15-dev mlir-15-tools
+      - run: PATH=/usr/lib/llvm-15/bin:$PATH cargo clippy -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
@@ -134,9 +134,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -177,9 +177,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -214,7 +214,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mlir-sys"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bindgen",
 ]
@@ -230,10 +230,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.1.0"
+name = "once_cell"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "peeking_take_while"
@@ -243,27 +249,27 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -272,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustc-hash"
@@ -311,19 +317,19 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,15 +30,20 @@ mod mlir_tests {
     #[test]
     fn test_location() {
         unsafe {
+            let registry = mlirDialectRegistryCreate();
             let context = mlirContextCreate();
 
-            mlirRegisterAllDialects(context);
+            mlirContextAppendDialectRegistry(context, registry);
+            mlirRegisterAllDialects(registry);
 
             let location = mlirLocationUnknownGet(context);
             let string = CString::new("newmod").unwrap();
             let reference = mlirStringRefCreateFromCString(string.as_ptr());
 
             mlirOperationStateGet(reference, location);
+
+            mlirContextDestroy(context);
+            mlirDialectRegistryDestroy(registry);
         }
     }
 }

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -2,11 +2,14 @@
 
 set -e
 
-llvm_version=14
+# TODO Use Homebrew to install LLVM 15.
+# llvm_version=15
 
-brew update
-brew install llvm@$llvm_version
+# brew update
+# brew install llvm@$llvm_version
 
-if [ -n "$GITHUB_ENV" ]; then
-  echo PATH=$(brew --prefix)/opt/llvm@$llvm_version/bin:$PATH >>$GITHUB_ENV
-fi
+# echo PATH=$(brew --prefix)/opt/llvm@$llvm_version/bin:$PATH >>$GITHUB_ENV
+
+curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
+sudo apt -y install libmlir-15-dev mlir-15-tools
+echo PATH=/usr/lib/llvm-15/bin:$PATH >>$GITHUB_ENV

--- a/wrapper.h
+++ b/wrapper.h
@@ -6,22 +6,22 @@
 #include <mlir-c/Debug.h>
 #include <mlir-c/Diagnostics.h>
 #include <mlir-c/Dialect/Async.h>
+#include <mlir-c/Dialect/ControlFlow.h>
+#include <mlir-c/Dialect/Func.h>
 #include <mlir-c/Dialect/GPU.h>
-#include <mlir-c/Dialect/Linalg.h>
 #include <mlir-c/Dialect/LLVM.h>
+#include <mlir-c/Dialect/Linalg.h>
 #include <mlir-c/Dialect/PDL.h>
 #include <mlir-c/Dialect/Quant.h>
 #include <mlir-c/Dialect/SCF.h>
 #include <mlir-c/Dialect/Shape.h>
 #include <mlir-c/Dialect/SparseTensor.h>
-#include <mlir-c/Dialect/Standard.h>
 #include <mlir-c/Dialect/Tensor.h>
 #include <mlir-c/ExecutionEngine.h>
-#include <mlir-c/IntegerSet.h>
-// TODO This should be fixed on LLVM >14.0.6.
-// #include <mlir-c/Interfaces.h>
 #include <mlir-c/IR.h>
+#include <mlir-c/IntegerSet.h>
+#include <mlir-c/Interfaces.h>
 #include <mlir-c/Pass.h>
-#include <mlir-c/Registration.h>
+#include <mlir-c/RegisterEverything.h>
 #include <mlir-c/Support.h>
 #include <mlir-c/Transforms.h>


### PR DESCRIPTION
The current version of LLVM 15 in Homebrew doesn't allow completely static linking and I couldn't get it working in VMs on GitHub Actions.

But will you accept this change of only CI on Linux with LLVM installed through `apt` instead of `brew` temporarily?