### PR TITLE
Check LLVM version on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rust bindings to [the MLIR C API](https://mlir.llvm.org/docs/CAPI/).
 cargo add mlir-sys
 ```
 
-This crate searches a `llvm-config` command on build and uses it to determine build configurations related to LLVM and MLIR. You can also use a `MLIR_SYS_150_PREFIX` environment variable to specify a custom directory of LLVM installation.
+This crate searches an `llvm-config` command on build and uses it to determine build configurations related to LLVM and MLIR. You can also use a `MLIR_SYS_150_PREFIX` environment variable to specify a custom directory of LLVM installation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 Rust bindings to [the MLIR C API](https://mlir.llvm.org/docs/CAPI/).
 
+## Install
+
+```sh
+cargo add mlir-sys
+```
+
+This crate searches a `llvm-config` command on build and uses it to determine build configurations related to LLVM and MLIR. You can also use a `MLIR_SYS_150_PREFIX` environment variable to specify a custom directory of LLVM installation.
+
 ## License
 
 [MIT](LICENSE)

--- a/build.rs
+++ b/build.rs
@@ -77,7 +77,13 @@ fn get_system_libcpp() -> Option<&'static str> {
 }
 
 fn llvm_config(argument: &str) -> Result<String, Box<dyn Error>> {
-    let call = format!("llvm-config --link-static {}", argument);
+    let prefix = env::var("MLIR_SYS_150_PREFIX")?;
+    let prefix = Path::new(&prefix);
+    let call = format!(
+        "{} --link-static {}",
+        Path::join(prefix, "bin/llvm-config").display(),
+        argument
+    );
 
     Ok(str::from_utf8(
         &if cfg!(target_os = "windows") {

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,8 @@ use std::process::exit;
 use std::process::Command;
 use std::str;
 
+const LLVM_MAJOR_VERSION: usize = 15;
+
 fn main() {
     if let Err(error) = run() {
         eprintln!("{}", error);
@@ -19,8 +21,12 @@ fn main() {
 fn run() -> Result<(), Box<dyn Error>> {
     let version = llvm_config("--version")?;
 
-    if !version.starts_with("15.") {
-        return Err(format!("failed to find correct version of llvm-config: {}", version).into());
+    if !version.starts_with(&format!("{}.", LLVM_MAJOR_VERSION)) {
+        return Err(format!(
+            "failed to find correct version ({}.x.x) of llvm-config (found {})",
+            LLVM_MAJOR_VERSION, version
+        )
+        .into());
     }
 
     println!("cargo:rerun-if-changed=wrapper.h");

--- a/build.rs
+++ b/build.rs
@@ -94,7 +94,7 @@ fn get_system_libcpp() -> Option<&'static str> {
 
 fn llvm_config(argument: &str) -> Result<String, Box<dyn Error>> {
     let prefix = env::var("MLIR_SYS_150_PREFIX")
-        .map(|path| Path::new("bin").join(path))
+        .map(|path| Path::new(&path).join("bin"))
         .unwrap_or_default();
     let call = format!(
         "{} --link-static {}",

--- a/build.rs
+++ b/build.rs
@@ -77,7 +77,7 @@ fn get_system_libcpp() -> Option<&'static str> {
 }
 
 fn llvm_config(argument: &str) -> Result<String, Box<dyn Error>> {
-    let prefix = env::var("MLIR_SYS_150_PREFIX")?;
+    let prefix = env::var("MLIR_SYS_150_PREFIX").unwrap_or_default();
     let prefix = Path::new(&prefix);
     let call = format!(
         "{} --link-static {}",


### PR DESCRIPTION
The MLIR C API is still unstable so rather than expecting forward/backward compatibility. I think we should rather fail builds for unexpected version mismatches.

This PR also introduces a new `MLIR_SYS_150_PREFIX` similar to `llvm-sys.rs`.

# Example

```txt
> cargo build
   ...
   Compiling mlir-sys v0.1.2 (/home/raviqqe/src/github.com/femtomc/mlir-sys)
error: failed to run custom build command for `mlir-sys v0.1.2 (/home/raviqqe/src/github.com/femtomc/mlir-sys)`

Caused by:
  process didn't exit successfully: `/home/raviqqe/src/github.com/femtomc/mlir-sys/target/debug/build/mlir-sys-03bf93aaf536b322/build-script-build` (exit status: 1)
  --- stderr
  failed to find correct version (15.x.x) of llvm-config (found 13.0.1)
```
