### PR TITLE
Correctly propagate llvm-config errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mlir-sys"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bindgen",
 ]


### PR DESCRIPTION
Currently, due to the extra `sh`/`cmd` indirection, if the `llvm-config` fails in the middle of the build script (say in `--libnames`), it will emit an empty `rustc-link-lib` name because the error is not propagated. The error is also not shown, and cargo will fail with a mysterious "library name must not be empty".

Remove this extra indirection and improve the error messages by showing the full context if this happens.

Fixes #45